### PR TITLE
6 刷に合わせた改訂

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@
 ### 「Kaggle (py310)」での主な変更点
 
 - 注：乱数やライブラリの仕様変更などの問題で、初版と合わせた公開したファイルと実行結果が一致しない場合があります。
-- LightGBMの[仕様変更](https://github.com/microsoft/LightGBM/pull/4908)に伴い`early_stopping_rounds`引数を削除しました。
-- ch03_02.ipynbで`dataiter.next()`を`next(dataiter)`に変更しました。
-- ch03_03.ipynbで`word2vec.Word2Vec`の引数の`size`を`vector_size`に変更しました。
+- 第5刷：LightGBMの[仕様変更](https://github.com/microsoft/LightGBM/pull/4908)に伴い`early_stopping_rounds`引数を削除しました。
+- 第5刷：ch03_02.ipynbで`dataiter.next()`を`next(dataiter)`に変更しました。
+- 第5刷：ch03_03.ipynbで`word2vec.Word2Vec`の引数の`size`を`vector_size`に変更しました。
+- 第6刷：ch02_03.ipynbでimportするライブラリ名を`pandas_profiling`から`ydata_profiling`に変更しました。
 
 ## よくある質問（FAQ）
 

--- a/footnote.md
+++ b/footnote.md
@@ -13,7 +13,7 @@
 - [9] Docker: Enterprise Container Platform, https://www.docker.com/ (Accessed: 30 November 2019).
 - [10] Container Registry - Google Cloud Platform, https://console.cloud.google.com/gcr/images/kaggle-images/GLOBAL/python (Accessed: 30 November 2019).
 - [11] PetFinder.my Adoption Prediction, https://www.kaggle.com/c/petfinder-adoption-prediction (Accessed: 30 November 2019).
-- [12] Kaggle Days Tokyo, https://kaggledays.com/tokyo/ (Accessed: 30 November 2019).
+- [12] Kaggle Days Tokyo, https://www.kaggle.com/c/kaggle-days-tokyo (Accessed: 10 March 2024).
 - [13] 機械学習を用いた日経電子版Proのユーザ分析 データドリブンチームの知られざる取り組み, https://logmi.jp/tech/articles/321077 (Accessed: 30 November 2019).
 - [14] Santander Value Prediction Challenge, https://www.kaggle.com/c/santander-value-prediction-challenge (Accessed: 30 November 2019).
 - [15] LANL Earthquake Prediction, https://www.kaggle.com/c/LANL-Earthquake-Prediction (Accessed: 30 November 2019).


### PR DESCRIPTION
- ライブラリ名を `ydata_profiling` に変更
- https://kaggledays.com/tokyo/ の URL を差し替え
